### PR TITLE
Fix app crash when inflating the note open modes menu after editing a note

### DIFF
--- a/app/src/main/java/app/notesr/activity/file/viewer/FileViewerActivityBase.java
+++ b/app/src/main/java/app/notesr/activity/file/viewer/FileViewerActivityBase.java
@@ -160,7 +160,7 @@ public class FileViewerActivityBase extends ActivityBase {
         showConfirmationDialog(
                 R.layout.dialog_action_cannot_be_undo,
                 R.string.warning,
-                R.string.delete,
+                R.string.delete_caps,
                 (dialog, which) -> runWithProgressDialog(task, post)
         );
     }

--- a/app/src/main/java/app/notesr/activity/note/DeleteNoteOnClick.java
+++ b/app/src/main/java/app/notesr/activity/note/DeleteNoteOnClick.java
@@ -25,7 +25,7 @@ import app.notesr.service.note.NoteService;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class DeleteNoteOnClick implements MenuItem.OnMenuItemClickListener {
+public final class DeleteNoteOnClick implements MenuItem.OnMenuItemClickListener {
 
     private final ActivityBase activity;
     private final Note note;

--- a/app/src/main/java/app/notesr/activity/note/DeleteNoteOnClick.java
+++ b/app/src/main/java/app/notesr/activity/note/DeleteNoteOnClick.java
@@ -38,7 +38,7 @@ public class DeleteNoteOnClick implements MenuItem.OnMenuItemClickListener {
         DialogInterface.OnClickListener buttonHandler = deleteNoteDialogOnClick();
         dialogFactory.getThemedAlertDialogBuilder(R.layout.dialog_action_cannot_be_undo)
                 .setTitle(R.string.warning)
-                .setPositiveButton(R.string.delete, buttonHandler)
+                .setPositiveButton(R.string.delete_caps, buttonHandler)
                 .setNegativeButton(R.string.no, buttonHandler)
                 .create()
                 .show();

--- a/app/src/main/java/app/notesr/activity/note/OpenFilesListOnClick.java
+++ b/app/src/main/java/app/notesr/activity/note/OpenFilesListOnClick.java
@@ -17,7 +17,7 @@ import app.notesr.data.model.Note;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class OpenFilesListOnClick implements MenuItem.OnMenuItemClickListener, View.OnClickListener {
+public final class OpenFilesListOnClick implements MenuItem.OnMenuItemClickListener, View.OnClickListener {
 
     private final ActivityBase activity;
     private final Note note;

--- a/app/src/main/java/app/notesr/activity/note/OpenNoteActivity.java
+++ b/app/src/main/java/app/notesr/activity/note/OpenNoteActivity.java
@@ -246,7 +246,7 @@ public final class OpenNoteActivity extends ActivityBase {
     }
 
     private void changeOpenModeButtonOnClick() {
-        View anchor = findViewById(R.id.changeOpenModeButton);
+        View anchor = findViewById(R.id.popupMenuAnchor);
         PopupMenu popup = new PopupMenu(this, anchor);
         popup.inflate(R.menu.menu_open_node_open_mode);
 

--- a/app/src/main/java/app/notesr/activity/note/SaveNoteOnClick.java
+++ b/app/src/main/java/app/notesr/activity/note/SaveNoteOnClick.java
@@ -24,7 +24,7 @@ import app.notesr.service.note.NoteService;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class SaveNoteOnClick implements MenuItem.OnMenuItemClickListener {
+public final class SaveNoteOnClick implements MenuItem.OnMenuItemClickListener {
 
     private final ActivityBase activity;
     private final Note note;

--- a/app/src/main/res/layout/activity_open_note.xml
+++ b/app/src/main/res/layout/activity_open_note.xml
@@ -98,4 +98,13 @@
 
     </ScrollView>
 
+    <ImageButton
+        android:id="@+id/popupMenuAnchor"
+        android:layout_width="1dp"
+        android:layout_height="1dp"
+        android:visibility="invisible"
+        android:contentDescription="@string/invisible_popup_menu_anchor"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_open_note.xml
+++ b/app/src/main/res/menu/menu_open_note.xml
@@ -5,7 +5,7 @@
         android:id="@+id/saveNoteButton"
         android:icon="@android:drawable/ic_menu_save"
         android:orderInCategory="4"
-        android:title="@string/save_note"
+        android:title="@string/save"
         android:visible="false"
         app:showAsAction="always" />
 
@@ -13,7 +13,7 @@
         android:id="@+id/deleteNoteButton"
         android:icon="@android:drawable/ic_menu_delete"
         android:orderInCategory="3"
-        android:title="@string/delete_note"
+        android:title="@string/delete"
         app:showAsAction="ifRoom" />
 
     <item
@@ -28,6 +28,6 @@
         android:id="@+id/changeOpenModeButton"
         android:icon="@drawable/ic_visibility"
         android:orderInCategory="1"
-        android:title="@string/change_open_mode"
+        android:title="@string/change_mode"
         app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,7 +36,8 @@
     <string name="this_action_cannot_be_undo_are_you_sure">This action cannot be undone.\nAre you sure?</string>
     <string name="yes">YES</string>
     <string name="no">NO</string>
-    <string name="delete">DELETE</string>
+    <string name="delete">Delete</string>
+    <string name="delete_caps">DELETE</string>
     <string name="enter_the_code">Enter the code!</string>
     <string name="note">Note</string>
     <string name="search">Search</string>
@@ -106,5 +107,6 @@
     <string name="re_encryption_failed_your_key_and_your_data_remains_unchanged">Re-encryption failed, your key and your data remains unchanged.</string>
     <string name="view_text">View Text</string>
     <string name="view_markdown">Markdown View</string>
-    <string name="change_open_mode">Change open mode</string>
+    <string name="change_mode">Change mode</string>
+    <string name="invisible_popup_menu_anchor">Invisible popup menu anchor</string>
 </resources>


### PR DESCRIPTION
Fixed an app crash that occurs when inflating the note open modes popup menu after editing a note.