### PR TITLE
Fix UI logic of export

### DIFF
--- a/app/src/main/java/app/notesr/activity/exporter/ExportActivity.java
+++ b/app/src/main/java/app/notesr/activity/exporter/ExportActivity.java
@@ -51,14 +51,7 @@ public final class ExportActivity extends ActivityBase {
     private ActionBar actionBar;
     private Button startStopButton;
 
-    private final ActivityResultLauncher<String> createDocumentLauncher = registerForActivityResult(
-            new ActivityResultContracts.CreateDocument("application/octet-stream"),
-            uri -> {
-                if (uri != null) {
-                    startService(uri);
-                }
-            }
-    );
+    private ActivityResultLauncher<String> exportDestinationPicker;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -116,6 +109,11 @@ public final class ExportActivity extends ActivityBase {
                 filesCountLabel.setText(String.format(getString(R.string.d_files), filesCount));
             });
         });
+
+        exportDestinationPicker = registerForActivityResult(
+                new ActivityResultContracts.CreateDocument("application/octet-stream"),
+                this::startExporting
+        );
     }
 
     private View.OnClickListener startStopButtonOnClick() {
@@ -131,14 +129,7 @@ public final class ExportActivity extends ActivityBase {
 
             runOnUiThread(() -> {
                 if (!isExportRunning()) {
-                    actionBar.setDisplayHomeAsUpEnabled(false);
-                    actionBar.setTitle(getString(R.string.exporting));
-
-                    disableBackButton(this);
-
                     pickSaveLocation();
-
-                    setCancelButton();
                 } else {
                     view.setEnabled(false);
                     cancelExport();
@@ -152,10 +143,22 @@ public final class ExportActivity extends ActivityBase {
         var nowStr = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss"));
         var filename = "nsr_export_" + nowStr + ".notesr.bak";
 
-        createDocumentLauncher.launch(filename);
+        exportDestinationPicker.launch(filename);
     }
 
-    private void startService(Uri uri) {
+    private void startExporting(Uri uri) {
+        if (uri != null) {
+            startExportService(uri);
+
+            actionBar.setDisplayHomeAsUpEnabled(false);
+            actionBar.setTitle(getString(R.string.exporting));
+
+            disableBackButton(this);
+            setCancelButton();
+        }
+    }
+
+    private void startExportService(Uri uri) {
         var versionFetcher = new VersionFetcherImpl();
 
         try {

--- a/app/src/main/java/app/notesr/activity/exporter/ExportActivity.java
+++ b/app/src/main/java/app/notesr/activity/exporter/ExportActivity.java
@@ -33,6 +33,7 @@ import app.notesr.R;
 import app.notesr.activity.ActivityBase;
 import app.notesr.core.security.crypto.AesCryptorFactory;
 import app.notesr.core.security.crypto.CryptoManagerProvider;
+import app.notesr.core.util.FileExifDataResolver;
 import app.notesr.core.util.FilesUtils;
 import app.notesr.data.DatabaseProvider;
 import app.notesr.service.AndroidServiceRegistry;
@@ -48,8 +49,10 @@ public final class ExportActivity extends ActivityBase {
 
     private NoteService noteService;
     private FileService fileService;
+
     private ActionBar actionBar;
     private Button startStopButton;
+    private TextView outputFileNameView;
 
     private ActivityResultLauncher<String> exportDestinationPicker;
 
@@ -75,17 +78,18 @@ public final class ExportActivity extends ActivityBase {
 
         actionBar = getSupportActionBar();
 
-        var dataReceiver = new ExportBroadcastReceiver(
-                this::onOutputPathReceived,
+        var serviceBroadcastReceiver = new ExportBroadcastReceiver(
                 this::onExportRunning,
                 this::onExportComplete
         );
 
-        LocalBroadcastManager.getInstance(this).registerReceiver(dataReceiver,
+        LocalBroadcastManager.getInstance(this).registerReceiver(serviceBroadcastReceiver,
                 new IntentFilter(ExportAndroidService.BROADCAST_ACTION));
 
         startStopButton = findViewById(R.id.start_stop_export_button);
         startStopButton.setOnClickListener(startStopButtonOnClick());
+
+        outputFileNameView = findViewById(R.id.output_file_name_view);
 
         if (isExportRunning()) {
             actionBar.setTitle(getString(R.string.exporting));
@@ -155,6 +159,13 @@ public final class ExportActivity extends ActivityBase {
 
             disableBackButton(this);
             setCancelButton();
+
+            String outputFileName = new FileExifDataResolver(this, new FilesUtils(), uri)
+                    .getFileName();
+
+            outputFileNameView.setVisibility(View.VISIBLE);
+            outputFileNameView.setText(
+                    String.format("%s %s", getString(R.string.saving_in), outputFileName));
         }
     }
 
@@ -170,13 +181,6 @@ public final class ExportActivity extends ActivityBase {
         } catch (PackageManager.NameNotFoundException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private void onOutputPathReceived(String outputPath) {
-        TextView outputPathView = findViewById(R.id.export_output_path_view);
-
-        outputPathView.setVisibility(View.VISIBLE);
-        outputPathView.setText(String.format("%s\n%s", getString(R.string.saving_in), outputPath));
     }
 
     private void onExportRunning(ExportStatus status, int progress) {

--- a/app/src/main/java/app/notesr/activity/exporter/ExportActivity.java
+++ b/app/src/main/java/app/notesr/activity/exporter/ExportActivity.java
@@ -15,6 +15,7 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ProgressBar;
@@ -47,6 +48,8 @@ import app.notesr.util.VersionFetcherImpl;
 
 public final class ExportActivity extends ActivityBase {
 
+    private static final String TAG = ExportActivity.class.getSimpleName();
+
     private NoteService noteService;
     private FileService fileService;
 
@@ -55,6 +58,8 @@ public final class ExportActivity extends ActivityBase {
     private TextView outputFileNameView;
 
     private ActivityResultLauncher<String> exportDestinationPicker;
+
+    private boolean isExportCompleted = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -208,14 +213,20 @@ public final class ExportActivity extends ActivityBase {
     }
 
     private void onExportComplete(ExportStatus status) {
-        if (status == ExportStatus.DONE) {
-            showToastMessage(this, getString(R.string.exported), Toast.LENGTH_LONG);
-        } else if (status == ExportStatus.ERROR) {
-            showToastMessage(this, getString(R.string.export_failed), Toast.LENGTH_LONG);
-        }
+        if (!isExportCompleted) {
+            isExportCompleted = true;
 
-        startActivity(new Intent(getApplicationContext(), NotesListActivity.class));
-        finish();
+            if (status == ExportStatus.DONE) {
+                showToastMessage(this, getString(R.string.exported), Toast.LENGTH_LONG);
+            } else if (status == ExportStatus.ERROR) {
+                showToastMessage(this, getString(R.string.export_failed), Toast.LENGTH_LONG);
+            }
+
+            startActivity(new Intent(getApplicationContext(), NotesListActivity.class));
+            finish();
+        } else {
+            Log.i(TAG, "Export already completed, ignoring duplicate completion signal");
+        }
     }
 
     private void setCancelButton() {

--- a/app/src/main/java/app/notesr/activity/exporter/ExportBroadcastReceiver.java
+++ b/app/src/main/java/app/notesr/activity/exporter/ExportBroadcastReceiver.java
@@ -20,26 +20,19 @@ import lombok.RequiredArgsConstructor;
 public final class ExportBroadcastReceiver extends BroadcastReceiver {
     private static final int DEFAULT_PROGRESS = -1;
 
-    private final Consumer<String> onOutputPathReceived;
     private final BiConsumer<ExportStatus, Integer> onExportRunning;
     private final Consumer<ExportStatus> onExportComplete;
 
     @Override
     public void onReceive(Context context, Intent intent) {
         if (ExportAndroidService.BROADCAST_ACTION.equals(intent.getAction())) {
-            if (intent.hasExtra(ExportAndroidService.EXTRA_OUTPUT_PATH)) {
-                onOutputPathReceived(intent);
-            }
-
             if (intent.hasExtra(ExportAndroidService.EXTRA_STATUS)) {
                 onStatusReceived(intent);
+            } else {
+                throw new IllegalArgumentException("Unexpected intent action: "
+                        + intent.getAction());
             }
         }
-    }
-
-    private void onOutputPathReceived(Intent intent) {
-        String outputPath = intent.getStringExtra(ExportAndroidService.EXTRA_OUTPUT_PATH);
-        onOutputPathReceived.accept(outputPath);
     }
 
     private void onStatusReceived(Intent intent) {

--- a/app/src/main/res/layout/activity_export.xml
+++ b/app/src/main/res/layout/activity_export.xml
@@ -73,7 +73,7 @@
         app:layout_constraintStart_toStartOf="parent" />
 
     <TextView
-        android:id="@+id/export_output_path_view"
+        android:id="@+id/output_file_name_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"

--- a/service/src/main/java/app/notesr/service/exporter/ExportAndroidService.java
+++ b/service/src/main/java/app/notesr/service/exporter/ExportAndroidService.java
@@ -124,9 +124,7 @@ public final class ExportAndroidService extends AndroidService implements Runnab
     @Override
     public void run() {
         var uri = Uri.parse(outputUri);
-
         registerCancelSignalReceiver();
-        broadcastOutputPath(uri.getPath());
 
         try (OutputStream outputStream = getContentResolver().openOutputStream(uri)) {
             if (outputStream == null) {
@@ -144,11 +142,6 @@ public final class ExportAndroidService extends AndroidService implements Runnab
     @Override
     public void onTaskRemoved(Intent rootIntent) {
         super.onTaskRemoved(rootIntent);
-    }
-
-    private void broadcastOutputPath(String outputPath) {
-        Intent broadcast = new Intent(BROADCAST_ACTION).putExtra(EXTRA_OUTPUT_PATH, outputPath);
-        LocalBroadcastManager.getInstance(this).sendBroadcast(broadcast);
     }
 
     private void registerCancelSignalReceiver() {

--- a/service/src/main/java/app/notesr/service/exporter/ExportService.java
+++ b/service/src/main/java/app/notesr/service/exporter/ExportService.java
@@ -77,8 +77,8 @@ public final class ExportService {
             statusHolder.setStatus(ExportStatus.ENCRYPTING_DATA);
             encryptFinalFile(backupEncryptor, outputStream);
 
+            statusHolder.setProgress(100);
             statusHolder.setStatus(ExportStatus.DONE);
-            statusHolder.setProgress(calculateProgress());
         } catch (ExportCancelledException e) {
             statusHolder.setStatus(ExportStatus.CANCELED);
         } catch (Throwable e) {


### PR DESCRIPTION
This change fixes the UI logic related to backup export. It fixes the issue where a user closes the save picker without choosing a location, leaving the ExportActivity in an invalid state. Also, it prevents duplicate messages about a finished export and replaces the raw URI of the selected save path with the simple backup file name.