### PR TITLE
Bump app version to 5.5.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "app.notesr"
         minSdk 29
         targetSdk 36
-        versionCode 62
-        versionName "5.5.0"
+        versionCode 63
+        versionName "5.5.1"
         buildConfigField "int", "DATA_SCHEMA_VERSION", "2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/fastlane/metadata/android/en-US/changelogs/63.txt
+++ b/fastlane/metadata/android/en-US/changelogs/63.txt
@@ -1,0 +1,9 @@
+Improvements:
+
+• Improved the Save Note button behavior; it now only appears when a note is available to save.
+• Various internal improvements.
+
+Bug Fixes:
+
+• Fixed a UI bug on the export screen.
+• Fixed a bug with the Save button when creating a new note.


### PR DESCRIPTION
Updated the app version to 5.5.1 and the version code to 63.
Added Fastlane changelog for the new version.