### PR TITLE
Update AppCloseAndroidService to clear SecretCache

### DIFF
--- a/service/src/main/java/app/notesr/service/lifecycle/AppCloseAndroidService.java
+++ b/service/src/main/java/app/notesr/service/lifecycle/AppCloseAndroidService.java
@@ -17,7 +17,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 
-import app.notesr.core.security.crypto.CryptoManager;
+import app.notesr.core.security.SecretCache;
 import app.notesr.core.security.crypto.CryptoManagerProvider;
 import app.notesr.data.DatabaseProvider;
 import app.notesr.service.AndroidService;
@@ -81,6 +81,7 @@ public final class AppCloseAndroidService extends AndroidService {
     @Override
     public void onTaskRemoved(Intent rootIntent) {
         if (getOtherRunningServicesCount() == 0) {
+            clearSecretCache();
             closeDatabase();
             destroySecrets();
 
@@ -114,6 +115,10 @@ public final class AppCloseAndroidService extends AndroidService {
                 .filter(serviceEntry ->
                         serviceEntry.getServiceClass() != getClass())
                 .count();
+    }
+
+    void clearSecretCache() {
+        SecretCache.clear();
     }
 
     void closeDatabase() {

--- a/service/src/test/java/app/notesr/service/lifecycle/AppCloseAndroidServiceTest.java
+++ b/service/src/test/java/app/notesr/service/lifecycle/AppCloseAndroidServiceTest.java
@@ -33,6 +33,7 @@ class AppCloseAndroidServiceTest {
     @Test
     void testOnTaskRemovedWhenNoOtherServicesRunningClosesEverythingAndExits() {
         doReturn(0L).when(service).getOtherRunningServicesCount();
+        doNothing().when(service).clearSecretCache();
         doNothing().when(service).closeDatabase();
         doNothing().when(service).destroySecrets();
         doNothing().when(service).stopForegroundService();
@@ -44,6 +45,9 @@ class AppCloseAndroidServiceTest {
 
         service.onTaskRemoved(intent);
 
+        verify(service, description("Secret cache should be cleared" +
+                " when no other services are running"))
+                .clearSecretCache();
         verify(service, description("Database should be closed" +
                 " when no other services are running"))
                 .closeDatabase();
@@ -74,6 +78,9 @@ class AppCloseAndroidServiceTest {
 
         service.onTaskRemoved(intent);
 
+        verify(service, never().description("Secret cache should NOT be cleared" +
+                " when other services are running"))
+                .clearSecretCache();
         verify(service, never().description("Database should NOT be closed" +
                 " when other services are running"))
                 .closeDatabase();


### PR DESCRIPTION
Updated `AppCloseAndroidService` to clear `SecretCache` on task removed triggered by app closing.