### PR TITLE
Handle CryptoSecrets validation in CbcToGcmKeyMigration

### DIFF
--- a/service/src/main/java/app/notesr/service/migration/changes/security/crypto/CbcToGcmKeyMigration.java
+++ b/service/src/main/java/app/notesr/service/migration/changes/security/crypto/CbcToGcmKeyMigration.java
@@ -33,7 +33,7 @@ public class CbcToGcmKeyMigration implements AppMigration {
 
             cryptoManager.setSecrets(context, secrets);
             secrets.destroy();
-        } catch (EncryptionFailedException e) {
+        } catch (EncryptionFailedException | IllegalArgumentException e) {
             throw new AppMigrationException("Failed to migrate key", e);
         }
     }

--- a/service/src/test/java/app/notesr/service/migration/changes/security/crypto/CbcToGcmKeyMigrationTest.java
+++ b/service/src/test/java/app/notesr/service/migration/changes/security/crypto/CbcToGcmKeyMigrationTest.java
@@ -5,6 +5,15 @@
 
 package app.notesr.service.migration.changes.security.crypto;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import android.content.Context;
 import app.notesr.core.security.exception.EncryptionFailedException;
 import app.notesr.service.migration.AppMigrationException;
@@ -17,8 +26,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CbcToGcmKeyMigrationTest {
@@ -61,6 +68,19 @@ class CbcToGcmKeyMigrationTest {
         AppMigrationException exception = assertThrows(
             AppMigrationException.class,
             () -> migration.migrate(context)
+        );
+
+        assertEquals("Failed to migrate key", exception.getMessage());
+    }
+
+    @Test
+    void testMigrateWhenSecretsValidationFailsThrowsAppMigrationException()
+            throws EncryptionFailedException {
+        doThrow(new IllegalArgumentException()).when(cryptoManager).setSecrets(any(), any());
+
+        AppMigrationException exception = assertThrows(
+                AppMigrationException.class,
+                () -> migration.migrate(context)
         );
 
         assertEquals("Failed to migrate key", exception.getMessage());


### PR DESCRIPTION
Added `IllegalArgumentException` handling to `CbcToGcmKeyMigration`, which is thrown if `CryptoSecrets` validation fails.