### PR TITLE
Bump app version to 5.6.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "app.notesr"
         minSdk 29
         targetSdk 36
-        versionCode 63
-        versionName "5.5.1"
+        versionCode 64
+        versionName "5.6.0"
         buildConfigField "int", "DATA_SCHEMA_VERSION", "2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/fastlane/metadata/android/en-US/changelogs/64.txt
+++ b/fastlane/metadata/android/en-US/changelogs/64.txt
@@ -1,0 +1,10 @@
+Improvements:
+
+• Added app bar with Back button to the key setup screen.
+• Improved navigation between the key setup and key import screens.
+• Implemented various internal enhancements.
+
+Bug Fixes:
+
+• Fixed critical bugs in the data re-encryption process.
+• Added additional checks for risky data-related operations.


### PR DESCRIPTION
Updated the app version to 5.6.0 and the version code to 64.
Added Fastlane changelog for the new version.