### PR TITLE
Refactor SetupKeyActivity to use Activity Result API for ImportKeyActivity

### DIFF
--- a/app/src/main/java/app/notesr/activity/security/ImportKeyActivity.java
+++ b/app/src/main/java/app/notesr/activity/security/ImportKeyActivity.java
@@ -11,9 +11,9 @@ import static java.util.Objects.requireNonNull;
 
 import static app.notesr.core.util.ActivityUtils.showToastMessage;
 import static app.notesr.core.util.CharUtils.bytesToChars;
+import static app.notesr.core.util.CharUtils.charsToBytes;
 import static app.notesr.core.util.KeyUtils.getSecretsFromHex;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.text.Editable;
 import android.util.Log;
@@ -31,18 +31,15 @@ import java.util.Arrays;
 import app.notesr.R;
 import app.notesr.activity.ActivityBase;
 import app.notesr.core.security.SecretCache;
-import app.notesr.core.security.crypto.CryptoManager;
-import app.notesr.core.security.crypto.CryptoManagerProvider;
 import app.notesr.core.security.dto.CryptoSecrets;
-import app.notesr.service.security.crypto.setup.SecretsSetupService;
 
 public final class ImportKeyActivity extends ActivityBase {
 
+    public static final String CACHE_KEY_HEX_KEY = "hexKey";
     public static final String CACHE_KEY_PASSWORD = "password";
-    public static final String EXTRA_MODE = "mode";
     private static final String TAG = ImportKeyActivity.class.getCanonicalName();
 
-    private KeySetupMode mode;
+    private int resultCode = RESULT_CANCELED;
     private EditText keyField;
     private char[] hexKey;
     private char[] password;
@@ -58,7 +55,6 @@ public final class ImportKeyActivity extends ActivityBase {
         actionBar.setDisplayHomeAsUpEnabled(true);
         actionBar.setTitle(getResources().getString(R.string.import_key));
 
-        mode = KeySetupMode.valueOf(requireNonNull(getIntent().getStringExtra(EXTRA_MODE)));
         password = getPasswordFromCache();
 
         keyField = findViewById(R.id.importKeyField);
@@ -75,7 +71,8 @@ public final class ImportKeyActivity extends ActivityBase {
 
     @Override
     public void finish() {
-        wipeSecrets();
+        wipeUiFields();
+        setResult(resultCode);
         super.finish();
     }
 
@@ -87,14 +84,10 @@ public final class ImportKeyActivity extends ActivityBase {
             hexKeyEditable.getChars(0, hexKeyEditable.length(), hexKey, 0);
 
             if (hexKey.length > 0) {
-                Context context = getApplicationContext();
-                CryptoManager cryptoManager = CryptoManagerProvider.getInstance(context);
-
-                CryptoSecrets cryptoSecrets;
-
                 try {
-                    cryptoSecrets = getSecretsFromHex(hexKey, password);
+                    CryptoSecrets cryptoSecrets = getCryptoSecrets(hexKey, password);
                     cryptoSecrets.validate();
+                    cryptoSecrets.destroy();
                 } catch (IllegalArgumentException | IllegalStateException e) {
                     Log.e(TAG, "Invalid key", e);
                     showToastMessage(this, getString(R.string.invalid_key),
@@ -103,15 +96,28 @@ public final class ImportKeyActivity extends ActivityBase {
                     return;
                 }
 
-                SecretsSetupService secretsSetupService = new SecretsSetupService(
-                        getApplicationContext(),
-                        cryptoManager,
-                        cryptoSecrets
-                );
-
-                new KeySetupCompletionHandler(this, secretsSetupService, mode).handle();
+                putResultsToCache(hexKey);
+                
+                resultCode = RESULT_OK;
+                finish();
             }
         };
+    }
+    
+    private CryptoSecrets getCryptoSecrets(char[] hexKey, char[] password) {
+        char[] hexKeyCopy = Arrays.copyOf(hexKey, hexKey.length);
+        return getSecretsFromHex(hexKeyCopy, password);
+    }
+    
+    private void putResultsToCache(char[] hexKey) {
+        try {
+            SecretCache.put(CACHE_KEY_HEX_KEY, charsToBytes(hexKey,
+                    StandardCharsets.UTF_8));
+        } catch (CharacterCodingException e) {
+            throw new RuntimeException(e);
+        }
+
+        SecretCache.removeIfExists(CACHE_KEY_PASSWORD); // Should be already removed
     }
 
     private char[] getPasswordFromCache() {
@@ -124,14 +130,7 @@ public final class ImportKeyActivity extends ActivityBase {
         }
     }
 
-    private void wipeSecrets() {
-        // Clearing only key field, not password, because reference to password is stored in cache
-        // and still could be used by SetupKeyActivity. SetupKeyActivity as a parent activity
-        // is responsible to clear password from cache.
-        if (hexKey != null && hexKey.length > 0) {
-            Arrays.fill(hexKey, '\0');
-        }
-
+    private void wipeUiFields() {
         Editable hexKeyEditable = keyField.getText();
         hexKeyEditable.replace(0, hexKeyEditable.length(), "");
 

--- a/app/src/main/java/app/notesr/activity/security/KeySetupCompletionHandler.java
+++ b/app/src/main/java/app/notesr/activity/security/KeySetupCompletionHandler.java
@@ -32,6 +32,7 @@ public final class KeySetupCompletionHandler {
     private final ActivityBase activity;
     private final SecretsSetupService secretsSetupService;
     private final KeySetupMode mode;
+    private final CryptoSecrets cryptoSecrets;
 
     public void handle() {
         switch (mode) {
@@ -43,7 +44,7 @@ public final class KeySetupCompletionHandler {
 
     private void proceedFirstRun() {
         try {
-            secretsSetupService.apply();
+            secretsSetupService.applySecrets(cryptoSecrets);
 
             Context context = activity.getApplicationContext();
             Intent nextIntent = new Intent(context, NotesListActivity.class);
@@ -78,10 +79,11 @@ public final class KeySetupCompletionHandler {
     }
 
     private void onRegenerationConfirmed() {
-        CryptoSecrets secrets = secretsSetupService.getCryptoSecrets();
+        byte[] keyBytes = Arrays.copyOf(cryptoSecrets.getKey(),
+                cryptoSecrets.getKey().length);
 
-        byte[] keyBytes = Arrays.copyOf(secrets.getKey(), secrets.getKey().length);
-        char[] password = Arrays.copyOf(secrets.getPassword(), secrets.getPassword().length);
+        char[] password = Arrays.copyOf(cryptoSecrets.getPassword(),
+                cryptoSecrets.getPassword().length);
 
         try {
             byte[] passwordBytes = charsToBytes(password, StandardCharsets.UTF_8);
@@ -92,10 +94,11 @@ public final class KeySetupCompletionHandler {
             throw new RuntimeException(e);
         }
 
-        secrets.destroy();
+        cryptoSecrets.destroy();
 
-        Context context = activity.getApplicationContext();
-        activity.startActivity(new Intent(context, ReEncryptionActivity.class));
+        Intent reEncryptionIntent = new Intent(activity.getApplicationContext(),
+                ReEncryptionActivity.class);
+        activity.startActivity(reEncryptionIntent);
         activity.finish();
     }
 }

--- a/app/src/main/java/app/notesr/activity/security/SetupKeyActivity.java
+++ b/app/src/main/java/app/notesr/activity/security/SetupKeyActivity.java
@@ -11,8 +11,9 @@ import static app.notesr.core.util.ActivityUtils.copyToClipboard;
 import static app.notesr.core.util.ActivityUtils.showToastMessage;
 import static app.notesr.core.util.CharUtils.bytesToChars;
 import static app.notesr.core.util.CharUtils.charsToBytes;
+import static app.notesr.core.util.KeyUtils.getKeyHexFromSecrets;
+import static app.notesr.core.util.KeyUtils.getSecretsFromHex;
 
-import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
@@ -23,6 +24,10 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.activity.OnBackPressedCallback;
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.ActionBar;
 
 import java.nio.charset.CharacterCodingException;
@@ -34,8 +39,8 @@ import app.notesr.activity.ActivityBase;
 import app.notesr.core.security.SecretCache;
 import app.notesr.core.security.crypto.CryptoManager;
 import app.notesr.core.security.crypto.CryptoManagerProvider;
+import app.notesr.core.security.dto.CryptoSecrets;
 import app.notesr.service.security.crypto.setup.SecretsSetupService;
-import app.notesr.core.util.KeyUtils;
 import lombok.Getter;
 
 @Getter
@@ -48,7 +53,9 @@ public final class SetupKeyActivity extends ActivityBase {
 
     private KeySetupMode mode;
     private char[] password;
-    private SecretsSetupService keySetupService;
+    private ActivityResultLauncher<Intent> importKeyLauncher;
+    private SecretsSetupService secretsSetupService;
+    private CryptoSecrets cryptoSecrets;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -64,19 +71,13 @@ public final class SetupKeyActivity extends ActivityBase {
 
         password = getPasswordFromCache();
 
-        Context context = getApplicationContext();
-        CryptoManager cryptoManager = CryptoManagerProvider.getInstance(context);
+        importKeyLauncher = registerForActivityResult(
+                new ActivityResultContracts.StartActivityForResult(), getImportKeyCallback());
+        secretsSetupService = getSecretsSetupService();
+        cryptoSecrets = secretsSetupService.getSecretsWithRandomKey(password);
 
-        keySetupService = new SecretsSetupService(
-                getApplicationContext(),
-                cryptoManager,
-                password
-        );
-
-        TextView keyView = findViewById(R.id.aesKeyHex);
-        keyView.setText(KeyUtils.getKeyHexFromSecrets(keySetupService.getCryptoSecrets()));
-
-        adaptKeyView();
+        char[] hexKey = getKeyHexFromSecrets(cryptoSecrets);
+        showHexKey(hexKey);
 
         Button copyToClipboardButton = findViewById(R.id.copyAesKeyHex);
         Button importButton = findViewById(R.id.importHexKeyButton);
@@ -126,8 +127,9 @@ public final class SetupKeyActivity extends ActivityBase {
         SecretCache.removeIfExists(CACHE_KEY_PASSWORD);
     }
 
-    private void adaptKeyView() {
-        TextView keyView = findViewById(R.id.aesKeyHex);
+    private void showHexKey(char[] hexKey) {
+        TextView keyView = findViewById(R.id.hexKey);
+        keyView.setText(hexKey, 0, hexKey.length);
 
         if (getResources().getDisplayMetrics().heightPixels <= LOW_SCREEN_HEIGHT) {
             keyView.setTextSize(KEY_VIEW_TEXT_SIZE_FOR_LOW_SCREEN_HEIGHT);
@@ -136,7 +138,7 @@ public final class SetupKeyActivity extends ActivityBase {
 
     private View.OnClickListener copyKeyButtonOnClick() {
         return view -> {
-            String keyHex = ((TextView) findViewById(R.id.aesKeyHex)).getText().toString();
+            String keyHex = ((TextView) findViewById(R.id.hexKey)).getText().toString();
 
             copyToClipboard(this, keyHex);
             showToastMessage(this, getString(R.string.copied), Toast.LENGTH_SHORT);
@@ -154,9 +156,24 @@ public final class SetupKeyActivity extends ActivityBase {
                 throw new RuntimeException(e);
             }
 
-            Intent intent = new Intent(getApplicationContext(), ImportKeyActivity.class)
-                    .putExtra(ImportKeyActivity.EXTRA_MODE, mode.toString());
-            startActivity(intent);
+            Intent intent = new Intent(getApplicationContext(), ImportKeyActivity.class);
+            importKeyLauncher.launch(intent);
+        };
+    }
+
+    private ActivityResultCallback<ActivityResult> getImportKeyCallback() {
+        return result -> {
+            if (result.getResultCode() == RESULT_OK) {
+                byte[] hexKeyBytes = SecretCache.take(ImportKeyActivity.CACHE_KEY_HEX_KEY);
+
+                try {
+                    char[] hexKey = bytesToChars(hexKeyBytes, StandardCharsets.UTF_8);
+                    cryptoSecrets = getSecretsFromHex(hexKey, password);
+                    getCompletionHandler(cryptoSecrets).handle();
+                } catch (CharacterCodingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
         };
     }
 
@@ -170,13 +187,21 @@ public final class SetupKeyActivity extends ActivityBase {
         }
     }
 
+    private SecretsSetupService getSecretsSetupService() {
+        CryptoManager cryptoManager = CryptoManagerProvider.getInstance(getApplicationContext());
+        return new SecretsSetupService(getApplicationContext(), cryptoManager);
+    }
+
     private View.OnClickListener nextButtonOnClick() {
-        var handler = new KeySetupCompletionHandler(this, keySetupService, mode);
-        return view -> handler.handle();
+        return view -> getCompletionHandler(cryptoSecrets).handle();
+    }
+
+    private KeySetupCompletionHandler getCompletionHandler(CryptoSecrets cryptoSecrets) {
+        return new KeySetupCompletionHandler(this, secretsSetupService, mode, cryptoSecrets);
     }
 
     private void wipeKeyView() {
-        TextView keyView = findViewById(R.id.aesKeyHex);
+        TextView keyView = findViewById(R.id.hexKey);
         CharSequence seq = keyView.getText();
 
         if (seq != null && seq.length() > 0) {

--- a/app/src/main/res/layout/activity_setup_key.xml
+++ b/app/src/main/res/layout/activity_setup_key.xml
@@ -36,7 +36,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-        android:id="@+id/aesKeyHex"
+        android:id="@+id/hexKey"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textColor="@color/text_color"

--- a/core/src/main/java/app/notesr/core/security/crypto/CryptoManager.java
+++ b/core/src/main/java/app/notesr/core/security/crypto/CryptoManager.java
@@ -104,7 +104,7 @@ public final class CryptoManager {
     public CryptoSecrets generateSecrets(char[] password) {
         byte[] key = new byte[CryptoSecrets.MASTER_KEY_SIZE];
         secureRandom.nextBytes(key);
-        return new CryptoSecrets(Arrays.copyOf(key, key.length), password);
+        return new CryptoSecrets(key, password);
     }
 
     /**

--- a/core/src/main/java/app/notesr/core/util/KeyUtils.java
+++ b/core/src/main/java/app/notesr/core/util/KeyUtils.java
@@ -28,7 +28,7 @@ public final class KeyUtils {
         return secretKey;
     }
 
-    public static String getKeyHexFromSecrets(CryptoSecrets cryptoSecrets) {
+    public static char[] getKeyHexFromSecrets(CryptoSecrets cryptoSecrets) {
         return getHexFromKeyBytes(cryptoSecrets.getKey());
     }
 
@@ -36,12 +36,12 @@ public final class KeyUtils {
         return new CryptoSecrets(getKeyBytesFromHex(hex), password);
     }
 
-    public static String getHexFromKeyBytes(byte[] key) {
-        StringBuilder result = new StringBuilder();
+    public static char[] getHexFromKeyBytes(byte[] key) {
+        SecureStringBuilder result = new SecureStringBuilder();
         int lineLength = 0;
 
         for (int i = 0; i < key.length; i++) {
-            String hex = byteToHex(key[i]);
+            char[] hex = byteToHex(key[i]);
 
             if (lineLength < HEX_LINE_SIZE_LIMIT) {
                 result.append(hex);
@@ -62,7 +62,7 @@ public final class KeyUtils {
             }
         }
 
-        return result.toString().toUpperCase();
+        return result.toCharArray();
     }
 
     public static byte[] getKeyBytesFromHex(char[] hexChars) {
@@ -104,13 +104,16 @@ public final class KeyUtils {
         return true;
     }
 
-    private static String byteToHex(byte value) {
+    private static char[] byteToHex(byte value) {
         char[] hexDigits = new char[2];
 
         hexDigits[0] = Character.forDigit((value >> 4) & 0xF, 16);
         hexDigits[1] = Character.forDigit((value & 0xF), 16);
 
-        return String.valueOf(hexDigits);
+        hexDigits[0] = Character.toUpperCase(hexDigits[0]);
+        hexDigits[1] = Character.toUpperCase(hexDigits[1]);
+
+        return hexDigits;
     }
 
     private static int countHexTokens(char[] chars) {

--- a/core/src/test/java/app/notesr/core/util/KeyUtilsTest.java
+++ b/core/src/test/java/app/notesr/core/util/KeyUtilsTest.java
@@ -70,10 +70,10 @@ class KeyUtilsTest {
                 (byte) 0xCD, (byte) 0xEF
         };
 
-        String expected = "01 23 45 67 \n89 AB CD EF";
-        String actual = KeyUtils.getHexFromKeyBytes(key);
+        char[] expected = "01 23 45 67 \n89 AB CD EF".toCharArray();
+        char[] actual = KeyUtils.getHexFromKeyBytes(key);
 
-        assertEquals(expected, actual,
+        assertArrayEquals(expected, actual,
                 "Hex conversion should format key with spaces and newlines correctly");
     }
 
@@ -131,8 +131,8 @@ class KeyUtilsTest {
     void hexConversionRoundTrip() {
         byte[] originalKey = new byte[]{0x10, 0x20, 0x30, 0x40, 0x50, 0x60};
 
-        String hex = KeyUtils.getHexFromKeyBytes(originalKey);
-        byte[] restoredKey = KeyUtils.getKeyBytesFromHex(hex.toCharArray());
+        char[] hex = KeyUtils.getHexFromKeyBytes(originalKey);
+        byte[] restoredKey = KeyUtils.getKeyBytesFromHex(hex);
 
         assertArrayEquals(originalKey, restoredKey,
                 "Round-trip hex conversion should restore original key bytes");
@@ -141,9 +141,9 @@ class KeyUtilsTest {
     @Test
     void getHexFromCryptoSecretsDelegatesCorrectly() {
         CryptoSecrets secrets = new CryptoSecrets(new byte[]{0x0A, 0x0B}, "password".toCharArray());
-        String hex = KeyUtils.getKeyHexFromSecrets(secrets);
+        char[] hex = KeyUtils.getKeyHexFromSecrets(secrets);
 
-        assertEquals("0A 0B", hex,
+        assertArrayEquals("0A 0B".toCharArray(), hex,
                 "getKeyHexFromSecrets should correctly delegate to getHexFromKeyBytes");
     }
 

--- a/service/src/main/java/app/notesr/service/security/crypto/setup/SecretsSetupService.java
+++ b/service/src/main/java/app/notesr/service/security/crypto/setup/SecretsSetupService.java
@@ -18,15 +18,12 @@ import lombok.RequiredArgsConstructor;
 public final class SecretsSetupService {
     private final Context context;
     private final CryptoManager cryptoManager;
-    private final CryptoSecrets cryptoSecrets;
 
-    public SecretsSetupService(Context context, CryptoManager cryptoManager, char[] password) {
-        this.context = context;
-        this.cryptoManager = cryptoManager;
-        this.cryptoSecrets = cryptoManager.generateSecrets(password);
+    public CryptoSecrets getSecretsWithRandomKey(char[] password) {
+        return cryptoManager.generateSecrets(password);
     }
 
-    public void apply() throws EncryptionFailedException {
+    public void applySecrets(CryptoSecrets cryptoSecrets) throws EncryptionFailedException {
         cryptoManager.setSecrets(context, cryptoSecrets);
         cryptoSecrets.destroy();
     }


### PR DESCRIPTION
Refactor the key setup/import flow to use the Activity Result API for importing keys and to pass secrets between activities via the `SecretCache` instead of coupling directly to `SecretsSetupService`. Change `KeyUtils` and `CryptoManager` to use `char[]`/`SecureStringBuilder` for key hex handling, add new `SecretsSetupService` API methods (`getSecretsWithRandomKey`, `applySecrets`). Remove redurant master key copy in `generateSecrets` in `CryptoManager`.