### PR TITLE
Fix Javadoc for Android Service Framework

### DIFF
--- a/service/src/main/java/app/notesr/service/AndroidServiceBootstrapper.java
+++ b/service/src/main/java/app/notesr/service/AndroidServiceBootstrapper.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
  * <p>
  * This class handles the initialization and execution of services registered in the
  * {@link AndroidServiceRegistry}, distinguishing between those that can run immediately
- * and those that require user authorization (and thus access to {@link CryptoSecrets}).
+ * and those that require user authentication (and thus access to {@link CryptoSecrets}).
  */
 @RequiredArgsConstructor
 public final class AndroidServiceBootstrapper {
@@ -25,7 +25,7 @@ public final class AndroidServiceBootstrapper {
     private final AndroidServiceRegistry registry;
 
     /**
-     * Starts all auto-start services that do not require authorization.
+     * Starts all auto-start services that do not require authentication.
      *
      * @param context the Android application context used to initialize services
      */
@@ -38,7 +38,7 @@ public final class AndroidServiceBootstrapper {
     }
 
     /**
-     * Starts all auto-start services that require authorization.
+     * Starts all auto-start services that require authentication.
      *
      * @param context the Android application context used to initialize services
      * @param secrets the cryptographic secrets required for authenticated services

--- a/service/src/main/java/app/notesr/service/AndroidServiceEntry.java
+++ b/service/src/main/java/app/notesr/service/AndroidServiceEntry.java
@@ -53,7 +53,7 @@ public final class AndroidServiceEntry {
     private boolean autoStart;
 
     /**
-     * Indicates whether the service requires user authorization before it
+     * Indicates whether the service requires user authentication before it
      * can be started or accessed.
      */
     @JsonProperty(index = 5)


### PR DESCRIPTION
Clarifies the Javadoc in NoteSR's Android Service Framework by replacing `authorization` with `authentication`.