### PR TITLE
Fix AuthActivity back button bug during key recovery

### DIFF
--- a/app/src/main/java/app/notesr/activity/security/AuthHandler.java
+++ b/app/src/main/java/app/notesr/activity/security/AuthHandler.java
@@ -47,7 +47,7 @@ public final class AuthHandler {
     private final SecretsRotationService secretsRotationService;
     private final SecureStringBuilder passwordBuilder;
 
-    private int attempts = MAX_ATTEMPTS;
+    private int authAttempts = MAX_ATTEMPTS;
     private char[] createdPassword;
 
     public void authenticate() {
@@ -181,9 +181,9 @@ public final class AuthHandler {
     }
 
     private void onAuthenticationFailed() {
-        attempts--;
+        authAttempts--;
 
-        if (attempts == 0) {
+        if (authAttempts == 0) {
             try {
                 appSecurityService.blockApp();
             } catch (AppSecurityException e) {
@@ -202,7 +202,7 @@ public final class AuthHandler {
 
             showToastMessage(String.format(
                     activity.getString(R.string.wrong_code_you_have_n_attempts),
-                    attempts));
+                    authAttempts));
         }
 
         resetPassword();

--- a/app/src/main/java/app/notesr/activity/security/AuthHandler.java
+++ b/app/src/main/java/app/notesr/activity/security/AuthHandler.java
@@ -193,6 +193,7 @@ public final class AuthHandler {
             showToastMessage(R.string.blocked);
             activity.startActivity(new Intent(activity.getApplicationContext(),
                     KeyRecoveryActivity.class));
+            activity.finish();
         } else {
             try {
                 Thread.sleep(DELAY_AFTER_AUTH_FAILED);

--- a/app/src/main/java/app/notesr/activity/security/AuthHandler.java
+++ b/app/src/main/java/app/notesr/activity/security/AuthHandler.java
@@ -40,7 +40,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public final class AuthHandler {
     private static final int MAX_ATTEMPTS = 3;
-    private static final int ON_WRONG_PASSWORD_DELAY_MS = 1500;
+    private static final int DELAY_AFTER_AUTH_FAILED = 1500;
 
     private final AuthActivity activity;
     private final AppSecurityService appSecurityService;
@@ -195,7 +195,7 @@ public final class AuthHandler {
                     KeyRecoveryActivity.class));
         } else {
             try {
-                Thread.sleep(ON_WRONG_PASSWORD_DELAY_MS);
+                Thread.sleep(DELAY_AFTER_AUTH_FAILED);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }

--- a/app/src/main/java/app/notesr/activity/security/KeyRecoveryActivity.java
+++ b/app/src/main/java/app/notesr/activity/security/KeyRecoveryActivity.java
@@ -12,7 +12,6 @@ import static app.notesr.core.util.ActivityUtils.showToastMessage;
 import static app.notesr.core.util.CharUtils.charsToBytes;
 import static app.notesr.core.util.KeyUtils.getKeyBytesFromKeyHex;
 
-import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
@@ -30,10 +29,8 @@ import app.notesr.core.security.SecretCache;
 import app.notesr.service.security.AppSecurityException;
 import app.notesr.service.security.AppSecurityService;
 
-import java.io.IOException;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -41,6 +38,7 @@ public final class KeyRecoveryActivity extends ActivityBase {
     private static final String TAG = KeyRecoveryActivity.class.toString();
 
     private AppSecurityService appSecurityService;
+    private EditText hexKeyField;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -53,13 +51,13 @@ public final class KeyRecoveryActivity extends ActivityBase {
         ActionBar actionBar = getSupportActionBar();
         Objects.requireNonNull(actionBar).setTitle(getString(R.string.key_recovery));
 
-        EditText hexKeyField = findViewById(R.id.importRecoveryKeyField);
+        hexKeyField = findViewById(R.id.importRecoveryKeyField);
         Button applyButton = findViewById(R.id.applyRecoveryKeyButton);
 
         disableBackButton(this);
 
         hexKeyField.setImeOptions(IME_FLAG_NO_PERSONALIZED_LEARNING);
-        applyButton.setOnClickListener(applyButtonOnClick(hexKeyField));
+        applyButton.setOnClickListener(getApplyButtonOnClickListener());
     }
 
     @Override
@@ -67,7 +65,17 @@ public final class KeyRecoveryActivity extends ActivityBase {
         return false;
     }
 
-    private View.OnClickListener applyButtonOnClick(EditText hexKeyField) {
+    @Override
+    public void finish() {
+        if (hexKeyField != null) {
+            hexKeyField.getText().replace(0, hexKeyField.getText().length(), "");
+            hexKeyField.setText("");
+        }
+
+        super.finish();
+    }
+
+    private View.OnClickListener getApplyButtonOnClickListener() {
         return view -> {
             Editable hexKeyEditable = hexKeyField.getText();
             int hexKeyLength = hexKeyEditable.length();
@@ -77,56 +85,49 @@ public final class KeyRecoveryActivity extends ActivityBase {
                 hexKeyEditable.getChars(0, hexKeyLength, hexKey, 0);
 
                 try {
-                    apply(hexKeyField, hexKey);
+                    if (isMatch(hexKey)) {
+                        proceedKeyMatch(hexKey);
+                    } else {
+                        proceedKeyMismatch();
+                    }
                 } catch (IllegalArgumentException e) {
                     Log.e(TAG, "Invalid key", e);
                     showToastMessage(this, getString(R.string.invalid_key),
                             Toast.LENGTH_SHORT);
-                } catch (CharacterCodingException e) {
-                    throw new RuntimeException(e);
-                } catch (IOException | NoSuchAlgorithmException e) {
+                } catch (AppSecurityException | CharacterCodingException e) {
                     Log.e(TAG, e.toString());
                     throw new RuntimeException(e);
+                } finally {
+                    Arrays.fill(hexKey, '\0');
                 }
             }
         };
     }
 
-    private void apply(EditText hexKeyField, char[] hexKey)
-            throws IOException, NoSuchAlgorithmException {
+    private boolean isMatch(char[] hexKey) {
+        byte[] keyBytes = getKeyBytesFromKeyHex(Arrays.copyOf(hexKey, hexKey.length));
+        boolean isMatch = appSecurityService.isKeyMatchingWithStored(keyBytes);
 
-        char[] hexKeyCopy = Arrays.copyOf(hexKey, hexKey.length);
-        byte[] keyBytes = getKeyBytesFromKeyHex(hexKeyCopy);
-
-        Context context = getApplicationContext();
-
-        try {
-            if (appSecurityService.isKeyMatchingWithStored(keyBytes)) {
-                byte[] hexKeyBytes = charsToBytes(hexKey, StandardCharsets.UTF_8);
-                SecretCache.put(AuthActivity.CACHE_KEY_HEX_KEY, hexKeyBytes);
-
-                // The hex key has already been wiped by charsToBytes
-                wipeSecretData(keyBytes, hexKeyField);
-
-                var targetMode = AuthActivity.Mode.KEY_RECOVERY;
-                var authActivityIntent = new Intent(context, AuthActivity.class)
-                        .putExtra(AuthActivity.EXTRA_MODE, targetMode.toString());
-
-                startActivity(authActivityIntent);
-                finish();
-            } else {
-                showToastMessage(this,
-                        getString(R.string.wrong_key),
-                        Toast.LENGTH_SHORT);
-            }
-        } catch (AppSecurityException e) {
-            throw new RuntimeException(e);
-        }
+        Arrays.fill(keyBytes, (byte) 0);
+        return isMatch;
     }
 
-    private void wipeSecretData(byte[] keyBytes, EditText keyField) {
-        Arrays.fill(keyBytes, (byte) 0);
-        keyField.getText().replace(0, keyField.getText().length(), "");
-        keyField.setText("");
+    private void proceedKeyMatch(char[] hexKey) throws CharacterCodingException {
+        byte[] hexKeyBytes = charsToBytes(Arrays.copyOf(hexKey, hexKey.length),
+                StandardCharsets.UTF_8);
+        SecretCache.put(AuthActivity.CACHE_KEY_HEX_KEY, hexKeyBytes);
+
+        var targetMode = AuthActivity.Mode.KEY_RECOVERY;
+        var authActivityIntent = new Intent(getApplicationContext(), AuthActivity.class)
+                .putExtra(AuthActivity.EXTRA_MODE, targetMode.toString());
+
+        startActivity(authActivityIntent);
+        finish();
+    }
+
+    private void proceedKeyMismatch() {
+        showToastMessage(this,
+                getString(R.string.wrong_key),
+                Toast.LENGTH_SHORT);
     }
 }

--- a/app/src/main/java/app/notesr/activity/security/KeyRecoveryActivity.java
+++ b/app/src/main/java/app/notesr/activity/security/KeyRecoveryActivity.java
@@ -35,7 +35,7 @@ import java.util.Arrays;
 import java.util.Objects;
 
 public final class KeyRecoveryActivity extends ActivityBase {
-    private static final String TAG = KeyRecoveryActivity.class.toString();
+    private static final String TAG = KeyRecoveryActivity.class.getSimpleName();
 
     private AppSecurityService appSecurityService;
     private EditText hexKeyField;


### PR DESCRIPTION
Resolves a crash in `AuthActivity` caused by interrupting the key recovery flow.

### Problem

If a user enters an invalid password 3 times, submits a valid key, types a new password, but presses Back on the "Repeat New Password" screen, `AuthActivity` enters an invalid state. Subsequent attempts to enter the access code result in a `RuntimeException`.

### Solution

- Added a `finish()` call to `AuthActivity` when the app locks after the final failed attempt.
- Refactored `KeyRecoveryActivity` to improve the key application logic.